### PR TITLE
Created vagrantfile acoording to Assignment requirements, updated README for last exercise, updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.vagrant

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
-# operations
- The main entrypoint into the project
+# In order to run the application: #
 
-Unfortunately we were unable to build the docker compose file in time due to issues with GitHub tokens. The individual modules can be inspected and work as intended so the application can still be run through each individual module. 
+`docker compose pull`
 
-To check on our progress we refer to the `Docker` branch where we have started on the dokcer compose file. 
- 
+And then:
+
+`docker compose up`
+
+This will start the application and run the necessary docker containers,`app-frontend`, `app-service`, and `model-service`
+
+
+In order to test the app go to the url: http://localhost:3000/ once everything is running

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
         vb.memory = "4096"
       end
       # Setup private network, if required
-      node.vm.network "private_network", ip: "192.168.56.#{10+i}"
+      node.vm.network "private_network", ip: "192.168.57.#{10+i}"
     end
   end
 
@@ -23,6 +23,6 @@ Vagrant.configure("2") do |config|
       vb.cpus = 2
       vb.memory = "2048"
     end
-    controller.vm.network "private_network", ip: "192.168.56.10"
+    controller.vm.network "private_network", ip: "192.168.57.10"
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,28 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  N = 2 # Number of worker nodes
+  (1..N).each do |i|
+    config.vm.define "node#{i}" do |node|
+      node.vm.box = "bento/ubuntu-24.04"
+      node.vm.hostname = "node-#{i}"
+      node.vm.provider "virtualbox" do |vb|
+        vb.cpus = 2
+        vb.memory = "4096"
+      end
+      # Setup private network, if required
+      node.vm.network "private_network", ip: "192.168.56.#{10+i}"
+    end
+  end
+
+  config.vm.define "controller" do |controller|
+    controller.vm.box = "bento/ubuntu-24.04"
+    controller.vm.hostname = "controller"
+    controller.vm.provider "virtualbox" do |vb|
+      vb.cpus = 2
+      vb.memory = "2048"
+    end
+    controller.vm.network "private_network", ip: "192.168.56.10"
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,12 @@
+version: "3"
+
 services:
   model-service:
     image: ghcr.io/remla2024-team9/model-service:latest
     ports:
       - "5000:5000"
     networks:
-      - app-network
+      - my-net
 
   app-service:
     image: ghcr.io/remla2024-team9/app-service:latest
@@ -13,17 +15,17 @@ services:
     depends_on:
       - model-service
     networks:
-      - app-network
+      - my-net
 
   app-frontend:
     image: ghcr.io/remla2024-team9/app-frontend:latest
     ports:
       - "3000:3000"
-    environment:
-      - REACT_APP_API_URL=http://app-service:8080
+    depends_on:
+      - app-service
     networks:
-      - app-network
-  
+      - my-net
+
 networks:
-  app-network:
+  my-net:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,27 @@ services:
     image: ghcr.io/remla2024-team9/model-service:latest
     ports:
       - "5000:5000"
+    networks:
+      - app-network
 
   app-service:
     image: ghcr.io/remla2024-team9/app-service:latest
     ports:
       - "8080:8080"
+    depends_on:
+      - model-service
+    networks:
+      - app-network
 
   app-frontend:
     image: ghcr.io/remla2024-team9/app-frontend:latest
     ports:
       - "3000:3000"
+    environment:
+      - REACT_APP_API_URL=http://app-service:8080
+    networks:
+      - app-network
+  
+networks:
+  app-network:
+    driver: bridge


### PR DESCRIPTION
Introduces the `Vagrantfile` necessary for provisioning our development and testing environments. The setup includes one control node and two worker nodes, all running on Ubuntu 24.04. 

### **Technical Details**

Control Node: Configured with **2 vCPUs and 2048 MB of memory.**
Worker Nodes: Each worker node is configured with **2 vCPUs and 4096 MB of memory.**
Networking: Private networking is set up, with the control node on **192.168.56.10** and worker nodes on **192.168.56.11** and **192.168.56.12**.

### **How to Use**
Ensure you have Vagrant and VirtualBox installed on your machine

Starting the VMs: Navigate to the directory containing the Vagrantfile and run:
    
    `vagrant up`


**Accessing VMs:** After the VMs are running, you can access each machine via SSH using:

     `vagrant ssh <vm_name>`

Replace <vm_name> with either controller, node1, or node2 depending on which VM you wish to access.

Please try out these commands to see that they work as intended. 
    